### PR TITLE
Update workflows for build-resources v4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
       - "kernelsam"
     cooldown:
       default-days: 21
-      exclude-patterns:
+      exclude:
         - "senzing-factory/*"
     directory: "/"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,16 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    assignees:
+      - "kernelsam"
+    cooldown:
+      default-days: 21
+      exclude-patterns:
+        - "senzing-factory/*"
     directory: "/"
+    groups:
+      senzing-factory:
+        patterns:
+          - "senzing-factory/*"
     schedule:
       interval: "daily"

--- a/.github/workflows/add-labels-standardized.yaml
+++ b/.github/workflows/add-labels-standardized.yaml
@@ -14,14 +14,15 @@ jobs:
       issues: write
     secrets:
       ORG_MEMBERSHIP_TOKEN: ${{ secrets.ORG_MEMBERSHIP_TOKEN }}
-      SENZING_MEMBERS: ${{ secrets.SENZING_MEMBERS }}
+      MEMBERS: ${{ secrets.SENZING_MEMBERS }}
     uses: senzing-factory/build-resources/.github/workflows/add-labels-to-issue.yaml@v4
 
   slack-notification:
     needs: [add-issue-labels]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-issue-labels.outputs.job-status) }}
+    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-issue-labels.result) }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
-      job-status: ${{ needs.add-issue-labels.outputs.job-status }}
+      job-status: ${{ needs.add-issue-labels.result }}

--- a/.github/workflows/add-to-project-senzing-dependabot.yaml
+++ b/.github/workflows/add-to-project-senzing-dependabot.yaml
@@ -11,16 +11,17 @@ jobs:
     permissions:
       repository-projects: write
     secrets:
-      SENZING_GITHUB_PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
+      PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
     uses: senzing-factory/build-resources/.github/workflows/add-to-project-dependabot.yaml@v4
     with:
       project: ${{ vars.SENZING_GITHUB_ORGANIZATION_PROJECT }}
 
   slack-notification:
     needs: [add-to-project-dependabot]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-to-project-dependabot.outputs.job-status) }}
+    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-to-project-dependabot.result) }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
-      job-status: ${{ needs.add-to-project-dependabot.outputs.job-status }}
+      job-status: ${{ needs.add-to-project-dependabot.result }}

--- a/.github/workflows/add-to-project-senzing.yaml
+++ b/.github/workflows/add-to-project-senzing.yaml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       repository-projects: write
     secrets:
-      SENZING_GITHUB_PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
+      PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
     uses: senzing-factory/build-resources/.github/workflows/add-to-project.yaml@v4
     with:
       project-number: ${{ vars.SENZING_GITHUB_ORGANIZATION_PROJECT }}
@@ -21,9 +21,10 @@ jobs:
 
   slack-notification:
     needs: [add-to-project]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-to-project.outputs.job-status) }}
+    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-to-project.result) }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
-      job-status: ${{ needs.add-to-project.outputs.job-status }}
+      job-status: ${{ needs.add-to-project.result }}

--- a/.github/workflows/dependabot-approve-and-merge.yaml
+++ b/.github/workflows/dependabot-approve-and-merge.yaml
@@ -12,5 +12,5 @@ jobs:
       contents: write
       pull-requests: write
     secrets:
-      SENZING_GITHUB_CODEOWNER_PR_RW_TOKEN: ${{ secrets.SENZING_GITHUB_CODEOWNER_PR_RW_TOKEN }}
+      CODEOWNER_PR_RW_TOKEN: ${{ secrets.SENZING_GITHUB_CODEOWNER_PR_RW_TOKEN }}
     uses: senzing-factory/build-resources/.github/workflows/dependabot-approve-and-merge.yaml@v4

--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -13,6 +13,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-      pull-requests: read
+      pull-requests: write
       statuses: write
-    uses: senzing-factory/build-resources/.github/workflows/lint-workflows.yaml@v3
+    uses: senzing-factory/build-resources/.github/workflows/lint-workflows.yaml@v4

--- a/.github/workflows/move-pr-to-done-dependabot.yaml
+++ b/.github/workflows/move-pr-to-done-dependabot.yaml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       repository-projects: write
     secrets:
-      SENZING_GITHUB_PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
+      PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
     uses: senzing-factory/build-resources/.github/workflows/move-pr-to-done-dependabot.yaml@v4
     with:
       project: ${{ vars.SENZING_GITHUB_ORGANIZATION_PROJECT }}

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -4,12 +4,12 @@
   "words": [
     "CCLA",
     "CODEOWNER",
-    "ICLA",
-    "Senzing",
+    "cooldown",
     "esbenp",
+    "ICLA",
+    "kernelsam",
+    "Senzing",
     "stackoverflow"
   ],
-  "ignorePaths": [
-    ".git/**"
-  ]
+  "ignorePaths": [".git/**"]
 }


### PR DESCRIPTION
## Summary

- Rename secret keys for build-resources v4 (`SENZING_MEMBERS` → `MEMBERS`, etc.)
- Replace `.outputs.job-status` with `.result`
- Bump `pull-requests` permission to `write` in lint-repo.yaml
- Add `SLACK_CHANNEL` secret to slack notification callers
- Bump all `@v3`/`@v2` build-resources references to `@v4`
- Standardize dependabot config (assignees, cooldown, groups)
- Add `kernelsam` and `cooldown` to cspell dictionary